### PR TITLE
Use pod_target_xcconfig instead of xcconfig in the podspec

### DIFF
--- a/ARSLineProgress.podspec
+++ b/ARSLineProgress.podspec
@@ -116,5 +116,5 @@ Pod::Spec.new do |s|
   s.exclude_files = "Demo/*", "Carthage/*"
   # s.public_header_files = "Source/ARSLineProgress.swift"
   s.requires_arc = true
-  s.xcconfig = { 'SWIFT_VERSION' => '4.0' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
 end


### PR DESCRIPTION
Basically the same as https://github.com/CocoaLumberjack/CocoaLumberjack/issues/814, and @benasher44 did a great job of explaining this change.

The current podspec modifies the `xcconfig` for the entire `Pods` project, when it really only needs to be applied to this pod's project. This change keeps this pod's changes restricted to its project,t and leaves the user's settings to drive the rest of the pods.