### PR TITLE
Fix Objective-C compatibility

### DIFF
--- a/Source/ARSLineProgress.swift
+++ b/Source/ARSLineProgress.swift
@@ -10,7 +10,7 @@
 
 import UIKit
 
-public final class ARSLineProgress: NSObject {
+@objcMembers public final class ARSLineProgress: NSObject {
     
     public static var shown: Bool { return ars_currentLoader != nil ? true : false }
     public static var statusShown: Bool { return ars_currentStatus != nil ? true : false }

--- a/Source/ARSLineProgressCustomization.swift
+++ b/Source/ARSLineProgressCustomization.swift
@@ -10,7 +10,7 @@
 
 import UIKit
 
-final public class ARSLineProgressConfiguration: NSObject {
+@objcMembers final public class ARSLineProgressConfiguration: NSObject {
 	
 	public static var showSuccessCheckmark = true
 	


### PR DESCRIPTION
Thanks for creating ARSLineProgress and maintaining it!

I noticed that on version 3.0.0 (after the Swift 4.2 migration) some public methods are no longer accessible from Objective-C. This PR exposes the missing members to Objective-C. 